### PR TITLE
Remove model_flag from NUOPC cap

### DIFF
--- a/NUOPC/HYCOM_OceanComp.F90
+++ b/NUOPC/HYCOM_OceanComp.F90
@@ -125,7 +125,6 @@ module HYCOM_Mod
   integer           :: scalar_field_count       = 0
   integer           :: scalar_field_idx_grid_nx = 0
   integer           :: scalar_field_idx_grid_ny = 0
-  type(model_flag)  :: atm_model                = MODEL_DEFAULT
 #ifdef ESPC_TIMER
   real(kind=ESMF_KIND_R8) :: timer_beg, timer_end
   real(kind=ESMF_KIND_R8) :: espc_timer(6)
@@ -229,9 +228,7 @@ module HYCOM_Mod
     call HYCOM_AttributeGet(rc)
     if (ESMF_STDERRORCHECK(rc)) return
 
-    ! Set import/export field list
-    call set_impexp_fields(atm_model=atm_model, &
-      cpl_scalars=(scalar_field_count.gt.0))
+    call set_impexp_fields(cpl_scalars=(scalar_field_count.gt.0))
 
     contains ! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -521,17 +518,6 @@ module HYCOM_Mod
       end_sec = ESMF_UtilString2Int(value, rc=rc)
       if (ESMF_STDERRORCHECK(rc)) return
 
-      ! get atmosphere model type
-      call NUOPC_CompAttributeGet(model, name="ATM_model", &
-        isPresent=isPresent, isSet=isSet, rc=rc)
-      if (ESMF_STDERRORCHECK(rc)) return
-      if (isPresent .and. isSet) then
-        call NUOPC_CompAttributeGet(model, name="ATM_model", &
-          value=value, rc=rc)
-        if (ESMF_STDERRORCHECK(rc)) return
-        atm_model=trim(value)
-      end if
-
       ! get scalar field name
       call NUOPC_CompAttributeGet(model, name="ScalarFieldName", &
         isPresent=isPresent, isSet=isSet, rc=rc)
@@ -665,10 +651,6 @@ module HYCOM_Mod
         call ESMF_LogWrite(trim(logMsg),ESMF_LOGMSG_INFO)
         write (logMsg, "(A,(A,I0))") trim(cname)//': ', &
           'end_sec                 = ',end_sec
-        call ESMF_LogWrite(trim(logMsg),ESMF_LOGMSG_INFO)
-        value=atm_model
-        write (logMsg, "(A,(A,A))") trim(cname)//': ', &
-          'ATM_model               = ',trim(value)
         call ESMF_LogWrite(trim(logMsg),ESMF_LOGMSG_INFO)
         write (logMsg, "(A,(A,A))") trim(cname)//': ', &
           'ScalarFieldName         = ',trim(scalar_field_name)

--- a/NUOPC/hycom_nuopc_flags.F90
+++ b/NUOPC/hycom_nuopc_flags.F90
@@ -36,17 +36,6 @@ module hycom_nuopc_flags
     IMPORT_UNCOUPLED = import_flag(1),  & ! Removes all import fields
     IMPORT_FLEXIBLE  = import_flag(2)     ! Remove import if not connected
 
-  type model_flag
-    sequence
-    private
-      integer :: mdl
-  end type model_flag
-
-  type(model_flag), parameter :: &
-    MODEL_ERROR   = model_flag(-1), & ! Model setting is invalid
-    MODEL_DEFAULT = model_flag(0),  & ! Use default import fields
-    MODEL_DATM    = model_flag(1)     ! Use default import fields for DATM
-
 !===============================================================================
 ! public
 !===============================================================================
@@ -55,23 +44,16 @@ module hycom_nuopc_flags
   public IMPORT_REQUIRED
   public IMPORT_UNCOUPLED
   public IMPORT_FLEXIBLE
-  public model_flag
-  public MODEL_ERROR
-  public MODEL_DEFAULT
-  public MODEL_DATM
 
   public operator(==), assignment(=)
 
   interface operator (==)
     module procedure import_flag_eq
-    module procedure model_flag_eq
   end interface
 
   interface assignment (=)
     module procedure import_flag_toString
     module procedure import_flag_frString
-    module procedure model_flag_toString
-    module procedure model_flag_frString
   end interface
 
   !-----------------------------------------------------------------------------
@@ -122,45 +104,6 @@ module hycom_nuopc_flags
   end subroutine import_flag_frString
 
   !-----------------------------------------------------------------------------
-
-  function model_flag_eq(val1, val2)
-    logical model_flag_eq
-    type(model_flag), intent(in) :: val1, val2
-    model_flag_eq = (val1%mdl == val2%mdl)
-  end function model_flag_eq
-
-  !-----------------------------------------------------------------------------
-
-  subroutine model_flag_toString(string, val)
-    character(len=*), intent(out) :: string
-    type(model_flag), intent(in) :: val
-    if (val == MODEL_DEFAULT) then
-      write(string,'(a)') 'DEFAULT'
-    elseif (val == MODEL_DATM) then
-      write(string,'(a)') 'DATM'
-    else
-      write(string,'(a)') 'ERROR'
-    endif
-  end subroutine model_flag_toString
-
-  !-----------------------------------------------------------------------------
-
-  subroutine model_flag_frString(val, string)
-    type(model_flag), intent(out) :: val
-    character(len=*), intent(in) :: string
-    character(len=16) :: ustring
-    integer :: rc
-    ustring = ESMF_UtilStringUpperCase(string, rc=rc)
-    if (rc .ne. ESMF_SUCCESS) then
-      val = MODEL_ERROR
-    elseif (ustring .eq. 'DEFAULT') then
-      val = MODEL_DEFAULT
-    elseif (ustring .eq. 'DATM') then
-      val = MODEL_DATM
-    else
-      val = MODEL_ERROR
-    endif
-  end subroutine model_flag_frString
 
 !===============================================================================
 end module hycom_nuopc_flags

--- a/NUOPC/read_impexp_config_mod.F90
+++ b/NUOPC/read_impexp_config_mod.F90
@@ -63,45 +63,27 @@ module read_impexp_config_mod
 !===============================================================================
   contains
 !===============================================================================
-  subroutine set_impexp_fields(atm_model, cpl_scalars)
-    type(model_flag),intent(in) :: atm_model
+  subroutine set_impexp_fields(cpl_scalars)
     logical, intent(in)         :: cpl_scalars
 
     ! create default import fields
     if (allocated(dfltFldsImp)) deallocate(dfltFldsImp)
-    if (atm_model.eq.MODEL_DATM) then
-      allocate(dfltFldsImp(11))
-      dfltFldsImp = (/ &
-        hycom_fld_type("taux10   ","mean_zonal_moment_flx        ","N m-2     "), & !01 Faxa_taux
-        hycom_fld_type("tauy10   ","mean_merid_moment_flx        ","N m-2     "), & !02 Faxa_tauy
-        hycom_fld_type("airtmp   ","inst_temp_height_lowest      ","K         "), & !03 Sa_tbot
-        hycom_fld_type("airhum   ","inst_spec_humid_height_lowest","kg kg-1   "), & !04 Sa_shum
-        hycom_fld_type("prcp     ","mean_prec_rate               ","kg m-2 s-1"), & !05 Faxa_rain
-        hycom_fld_type("mslprs   ","inst_pres_height_surface     ","Pa        "), & !06 Sa_pslv
-        hycom_fld_type("swflx_net","mean_net_sw_flx              ","W m-2     "), & !07 Foxx_swnet
-        hycom_fld_type("lwflx_net","mean_net_lw_flx              ","W m-2     "), & !08 Foxx_lwnet
-        hycom_fld_type("wndspd10 ","inst_wind_speed_height_lowest","m s-1     "), & !09 Sa_wspd
-        hycom_fld_type("gt       ","inst_temp_skin_temperature   ","K         "), & !10 Sa_tskn
-        hycom_fld_type("sic      ","ice_fraction                 ","1         ")  & !11 Si_ifrac
-      /)
-    else
-      allocate(dfltFldsImp(13))
-      dfltFldsImp = (/ &
-        hycom_fld_type("u10    ","inst_zonal_wind_height10m","m s-1     "), & !01 Sa_u10m
-        hycom_fld_type("v10    ","inst_merid_wind_height10m","m s-1     "), & !02 Sa_v10m
-        hycom_fld_type("taux10 ","mean_zonal_moment_flx_atm","N m-2     "), & !03 Faxa_taux
-        hycom_fld_type("tauy10 ","mean_merid_moment_flx_atm","N m-2     "), & !04 Faxa_tauy
-        hycom_fld_type("airtmp ","inst_temp_height2m       ","K         "), & !05 Sa_t2m
-        hycom_fld_type("airhum ","inst_spec_humid_height2m ","kg kg-1   "), & !06 Sa_q2m
-        hycom_fld_type("prcp   ","mean_prec_rate           ","kg m-2 s-1"), & !07 Faxa_rain
-        hycom_fld_type("swflxd ","mean_net_sw_flx          ","W m-2     "), & !08 Faxa_swnet
-        hycom_fld_type("lwflxd ","mean_net_lw_flx          ","W m-2     "), & !09 Faxa_lwnet
-        hycom_fld_type("mslprs ","inst_pres_height_surface ","Pa        "), & !10 Sa_pslv
-        hycom_fld_type("gt     ","inst_temp_height_surface ","K         "), & !11 Sa_tskn
-        hycom_fld_type("sensflx","mean_sensi_heat_flx      ","W m-2     "), & !12 Faxa_sen
-        hycom_fld_type("latflx ","mean_laten_heat_flx      ","W m-2     ")  & !13 Faxa_lat
-      /)
-    end if
+    allocate(dfltFldsImp(13))
+    dfltFldsImp = (/ &
+      hycom_fld_type("u10    ","inst_zonal_wind_height10m","m s-1     "), & !01 Sa_u10m
+      hycom_fld_type("v10    ","inst_merid_wind_height10m","m s-1     "), & !02 Sa_v10m
+      hycom_fld_type("taux10 ","mean_zonal_moment_flx_atm","N m-2     "), & !03 Faxa_taux
+      hycom_fld_type("tauy10 ","mean_merid_moment_flx_atm","N m-2     "), & !04 Faxa_tauy
+      hycom_fld_type("airtmp ","inst_temp_height2m       ","K         "), & !05 Sa_t2m
+      hycom_fld_type("airhum ","inst_spec_humid_height2m ","kg kg-1   "), & !06 Sa_q2m
+      hycom_fld_type("prcp   ","mean_prec_rate           ","kg m-2 s-1"), & !07 Faxa_rain
+      hycom_fld_type("swflxd ","mean_net_sw_flx          ","W m-2     "), & !08 Faxa_swnet
+      hycom_fld_type("lwflxd ","mean_net_lw_flx          ","W m-2     "), & !09 Faxa_lwnet
+      hycom_fld_type("mslprs ","inst_pres_height_surface ","Pa        "), & !10 Sa_pslv
+      hycom_fld_type("gt     ","inst_temp_height_surface ","K         "), & !11 Sa_tskn
+      hycom_fld_type("sensflx","mean_sensi_heat_flx      ","W m-2     "), & !12 Faxa_sen
+      hycom_fld_type("latflx ","mean_laten_heat_flx      ","W m-2     ")  & !13 Faxa_lat
+    /)
 
     ! create default export fields
     if (allocated(dfltFldsExp)) deallocate(dfltFldsExp)


### PR DESCRIPTION
HYCOM cap code no longer depends on the model connection (i.e. UFSATM, DATM, etc)